### PR TITLE
Implemented support for default$ rule. See #6

### DIFF
--- a/lib/parambulator.js
+++ b/lib/parambulator.js
@@ -584,25 +584,49 @@ function Parambulator( spec, pref ) {
   }
 
 
-
   //var rulenames = proporder(spec)
   var rules = parse(spec)
-  parsedefault(spec, [])
+  parsedefault(spec, [], [])
 
-  function parsedefault(spec, path){
-    for( var name in spec){
-      var newpath = path.slice()
+  /*
+   * Example:
+   * For a: {default$:123, type$:'number'}
+   * creates {"pathnames":["a"],"pathtypes":[],"defaultvalue":123}
+   *
+   * for d: {type$: 'array', __0: {default$:'arraytest0'}}
+   * creates {"pathnames":["d","0"],"pathtypes":["array"],"defaultvalue":"arraytest0"}
+   */
+  function parsedefault(spec, path, pathtypes){
+    var innerulenames = []
+    var currentruletype = 'object'
+
+    for(var name in spec){
       var rule = spec[name]
-      if( _.isObject(rule) && !_.isArray(rule) ) {
-        newpath.push(name)
-        parsedefault(rule, newpath)
-      }
       if ('default$' == name){
         var defaultrule = {}
-        defaultrule.path = path
+        defaultrule.pathnames = path
+        
+        defaultrule.pathtypes = pathtypes.splice(1,pathtypes.length)
         defaultrule.defaultvalue = rule
         defaultrules.push(defaultrule)
       }
+      if ('type$' == name){
+        currentruletype = rule
+      }
+      if( _.isObject(rule) && !_.isArray(rule) ) {
+        innerulenames.push(name)
+      }
+    }
+
+    for (var index in innerulenames){
+      rule = spec[innerulenames[index]]
+
+      var newpath = path.slice()
+      newpath.push(innerulenames[index])
+
+      var newpathtypes = pathtypes.slice()
+      newpathtypes.push(currentruletype)
+      parsedefault(rule, newpath, newpathtypes)
     }
   }
 
@@ -754,22 +778,41 @@ function Parambulator( spec, pref ) {
       execrule(0)
     }
 
-    function validatedefaults(ctxt){
-      if (defaultrules.length == 0){
-        return
-      }
+   /*
+    * Example:
+    * For a: {"pathnames":["a"],"pathtypes":[],"defaultvalue":123}
+    * creates {a:123}
+    *
+    * for d: {"pathnames":["d","0"],"pathtypes":["array"],"defaultvalue":"arraytest0"}
+    * creates {d: ['arraytest0']}
+    */
+    function validatedefaults(ctxt, cb){
       for (var ruleindex in defaultrules){
         var rule = defaultrules[ruleindex]
         var obj = ctxt.point
 
-        for (var index = 0; index < rule.path.length; index++){
-          var location = rule.path[index]
+        for (var index in rule.pathnames){
+          var location = rule.pathnames[index]
           if ( !_.has(obj, location) ){
-            if (index == rule.path.length - 1){
+            // if is last in path then just add default value
+            if (index == rule.pathnames.length - 1){
               obj[location] = rule.defaultvalue
             }
+            // else create object or array and continue following path
             else{
-              var newobj = {}
+              var type = rule.pathtypes[index]
+              var newobj
+              if ('object' == type){
+                newobj = {}
+              }
+              else if ('array' == type){
+                newobj = []
+              }
+              else{
+                // cannot continue, call cb and return false;
+                ctxt.util.fail('default$',ctxt,cb)
+                return;
+              }
               obj[location] = newobj
               obj = newobj
             }
@@ -779,6 +822,7 @@ function Parambulator( spec, pref ) {
           }
         }
       }
+      cb();
     }
 
     var ctxt = {rules:rules,point:args,msgs:msgs,log:[],parents:[]}
@@ -793,9 +837,15 @@ function Parambulator( spec, pref ) {
       },
       fail:fail,proplist:proplist,execrules:execrules,clone:clone}
 
-    validatedefaults(ctxt)
-    execrules(ctxt,function(err){
-      wrapcb(err,{log:ctxt.log})
+    validatedefaults(ctxt,function(err){
+      if (err){
+        wrapcb(err,{log:ctxt.log})
+      }
+      else{
+        execrules(ctxt,function(err){
+          wrapcb(err,{log:ctxt.log})
+        })
+      }
     })
 
     // only works if no async calls inside rules

--- a/test/default.js
+++ b/test/default.js
@@ -16,11 +16,13 @@ vows.describe('default').addBatch({
           a: {default$:123, type$:'number'},
           b: {
               firstobj: {default$:23, type$:'number'}, 
-              secondobj: {default$:'testing', type$:'string'},
-              thirdobj: {innerobj: {default$:'test'},
-              }
+              secondobj: {innerobj: {default$:'test'}},
+              thirdobj: {type$:'array', __0: {default$:123}},  
             },
           c: {default$:555, type$:'number'},
+          d: {type$: 'array', __0: {default$:'arraytest0'}, __1: {default$:'arraytest1'}},
+          e: {type$: 'array', default$:[]},
+          f: {default$:'aa', type$:'number'}
         })
       } 
       catch( e ) {
@@ -30,9 +32,10 @@ vows.describe('default').addBatch({
     },
 
     'firsttest': function( pb ) {
-      var obj = {c: 123}
+      var obj = {c: 2222}
       pb.validate(obj,function(err,res){
-        assert.isNull(err)
+        assert.isNotNull(err)
+        assert.equal(err.parambulator.code,'type$')
       })
 
       assert.isTrue(_.has(obj, 'a'))
@@ -43,14 +46,46 @@ vows.describe('default').addBatch({
       assert.equal(obj['b']['firstobj'], 23)
 
       assert.isTrue(_.has(obj['b'], 'secondobj'))
-      assert.equal(obj['b']['secondobj'], 'testing')
+      assert.isTrue(_.has(obj['b']['secondobj'], 'innerobj'))
+      assert.equal(obj['b']['secondobj']['innerobj'], 'test')
 
       assert.isTrue(_.has(obj['b'], 'thirdobj'))
-      assert.isTrue(_.has(obj['b']['thirdobj'], 'innerobj'))
-      assert.equal(obj['b']['thirdobj']['innerobj'], 'test')
+      assert.isTrue(_.isArray(obj['b']['thirdobj']))
+      assert.equal(obj['b']['thirdobj'], '123')
 
       assert.isTrue(_.has(obj, 'c'))
-      assert.equal(obj['a'], 123)
+      assert.equal(obj['c'], 2222)
+
+      assert.isTrue(_.has(obj, 'd'))
+      assert.isTrue(_.isArray(obj['d']))
+      assert.equal('arraytest0', obj['d'][0])
+      assert.equal('arraytest1', obj['d'][1])
+
+      assert.isTrue(_.has(obj, 'e'))
+      assert.isTrue(_.isArray(obj['e']))
+      assert.equal(0, obj['e'].length)
+    },
+  },
+  'nice': {
+    topic: function() {
+      try {
+        return new parambulator.Parambulator({
+          c: {default$:555, type$:'number'},
+          d: {type$: 'number', __0: {default$:'arraytest0'}, __1: {default$:'arraytest1'}},
+        })
+      } 
+      catch( e ) {
+        console.log(e.stack)
+        throw e
+      }
+    },
+
+    'firsttest': function( pb ) {
+      var obj = {c: 2222}
+      pb.validate(obj,function(err,res){
+        assert.isNotNull(err)
+        assert.equal(err.parambulator.code,'default$')
+      })
     },
   }
 }).export(module)


### PR DESCRIPTION
Implemented support for default$ rule. If the path to the default$ rule does not exists in the validated object then it will be created.

If a property from this path has defined the type$ this will be used following the rules:
- if type$ is 'array' then an array will be created and process continues
- if type$ is 'object' then an object is created and process continues
- if type$ has any other value the process will fail with default$ code as it cannot continue.

Examples:
{ d: {type$: 'array', __0: {default$:'arraytest0'}, __1: {default$:'arraytest1'}} }
will create
{ d: ['arraytest0', 'arraytest1']}

but 

{ d: {type$: 'number', __0: {default$:'arraytest0'}, __1: {default$:'arraytest1'}} }
will generate error

If a property do not have the type$ defined then, by default an object will be defined.

Note: Maybe we should not accept this default behavior and report error if a property do not have a type$ defined.

Example:
{
.......
    b: {
        c: {default$:23, type$:'number'}
    }
.......
}

will create

{
...
b: {c:23}
...
}
As the type of property 'b' is unknown, in current implementation an object will be created and added to the validated object. Maybe we should report an error for this.

After the default values are added to object this will be validated using normal validation rule processing. This means that if the default value do not match the other rules of that property then validation will report error.

Example: 

{
...
a: {default$:'aaa', type$:number}
...
}

if validated object is 
{
...
a:123
...
}
no error will be generated (because values 123 is a number), but if the validated object do not contain property 'a' in the correct path then it will generate a type$ error (it will be added value 'aaa' which is not a number and validation will fail)

Note: we could take in consideration that in case of default$ error maybe we need to revert all changes on the validated object as this will be in an inconsistent state.
